### PR TITLE
Add Ruby tool registry

### DIFF
--- a/bin/mcp
+++ b/bin/mcp
@@ -4,4 +4,8 @@
 require "bundler/setup"
 require "mcp_lite"
 
+if ARGV.first
+  require ARGV.shift
+end
+
 McpLite.start_server

--- a/ext/mcp_lite/src/lib.rs
+++ b/ext/mcp_lite/src/lib.rs
@@ -7,5 +7,6 @@ use magnus::{function, prelude::*, Error, Ruby};
 fn init(ruby: &Ruby) -> Result<(), Error> {
     let module = ruby.define_module("McpLiteNative")?;
     module.define_singleton_method("start_server", function!(server::start_server, 0))?;
+    module.define_singleton_method("register_tool", function!(server::register_tool, 3))?;
     Ok(())
 }

--- a/ext/mcp_lite/src/utils.rs
+++ b/ext/mcp_lite/src/utils.rs
@@ -1,5 +1,5 @@
 use std::{ffi::c_void, mem::MaybeUninit, ptr::null_mut};
-use rb_sys::rb_thread_call_without_gvl;
+use rb_sys::{rb_thread_call_with_gvl, rb_thread_call_without_gvl};
 
 unsafe extern "C" fn call_without_gvl<F, R>(arg: *mut c_void) -> *mut c_void
 where
@@ -21,6 +21,32 @@ where
     let arg_ptr = &(&mut func, &result) as *const _ as *mut c_void;
     unsafe {
         rb_thread_call_without_gvl(Some(call_without_gvl::<F, R>), arg_ptr, None, null_mut());
+        result.assume_init()
+    }
+}
+
+unsafe extern "C" fn call_with_gvl<F, R>(arg: *mut c_void) -> *mut c_void
+where
+    F: FnOnce() -> R,
+    R: Sized,
+{
+    let arg = arg as *mut Option<(F, *mut MaybeUninit<R>)>;
+    // SAFETY: pointer is valid and owned by caller
+    let (func, result) = unsafe { (*arg).take().unwrap() };
+    unsafe { (*result).write(func()) };
+    null_mut()
+}
+
+pub fn with_gvl<F, R>(func: F) -> R
+where
+    F: FnOnce() -> R,
+    R: Sized,
+{
+    let mut result = MaybeUninit::uninit();
+    let mut data: Option<(F, *mut MaybeUninit<R>)> = Some((func, &mut result));
+    let arg_ptr = &mut data as *mut _ as *mut c_void;
+    unsafe {
+        rb_thread_call_with_gvl(Some(call_with_gvl::<F, R>), arg_ptr);
         result.assume_init()
     }
 }

--- a/lib/mcp_lite.rb
+++ b/lib/mcp_lite.rb
@@ -2,6 +2,7 @@
 
 require_relative "mcp_lite/version"
 require_relative "mcp_lite/mcp_lite"
+require_relative "mcp_lite/tool_registry"
 require_relative "mcp_lite/server"
 
 module McpLite

--- a/lib/mcp_lite/tool_registry.rb
+++ b/lib/mcp_lite/tool_registry.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module McpLite
+  module ToolRegistry
+    def self.register_tool(name:, description: nil, &block)
+      raise ArgumentError, "block required" unless block
+
+      McpLiteNative.register_tool(name, description, block)
+    end
+  end
+end

--- a/test/support/say_hello_tool.rb
+++ b/test/support/say_hello_tool.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+McpLite::ToolRegistry.register_tool(
+  name: "say_hello_world",
+  description: "Prints 'Hello World!' message"
+) do |_request|
+  "Hello World!"
+end


### PR DESCRIPTION
## Summary
- allow tools to be registered from Ruby
- expose new `register_tool` API via magnus
- implement Ruby registry and default `say_hello_world` tool
- update integration test to run `bin/mcp`
- move the default tool to a test script

## Testing
- `bundle exec rake`


------
https://chatgpt.com/codex/tasks/task_e_6856ace0b2648332bbbd60441f888d5c